### PR TITLE
Update info.plist developer url

### DIFF
--- a/GlyphPalette.roboFontExt/info.plist
+++ b/GlyphPalette.roboFontExt/info.plist
@@ -7,7 +7,7 @@
 	<key>developer</key>
 	<string>Rafał Buchner</string>
 	<key>developerURL</key>
-	<string>rafalbuchner.com</string>
+	<string>https://rafalbuchner.com</string>
 	<key>html</key>
 	<false/>
 	<key>launchAtStartUp</key>


### PR DESCRIPTION
we're trying to improve info.plist validation in the mechanic2 ecosystem

(the url points to nowwhere, it might be a good opportunity to update it!)